### PR TITLE
Upgrade apiVersion to 3

### DIFF
--- a/src/block.json
+++ b/src/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "tabor/markdown-comment",
 	"title": "Markdown Comment",
 	"category": "text",


### PR DESCRIPTION
With apiVersion 3 it's possible that the editor loads the content in an iframe. See https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/